### PR TITLE
Increase maxListeners limit

### DIFF
--- a/RedisAdapter.js
+++ b/RedisAdapter.js
@@ -19,6 +19,7 @@ function RedisAdapter(uid, prefix, pub, sub, namespace) {
   this.prefix = prefix;
   this.pubClient = pub;
   this.subClient = sub;
+  this.subClient.setMaxListeners(50);
   this.onmessage = this.onmessage.bind(this);
   this._subscribe();
 }


### PR DESCRIPTION
Empêche le warning : 

```
(node) warning: possible EventEmitter memory leak detected. 11 message listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
at RedisClient.addListener (events.js:179:15)
at RedisAdapter._subscribe (/space/mirror/Deploy/releases/20150324133527/node_modules/socket.io-redis-fixed-memleak/RedisAdapter.js:36:18)
at new RedisAdapter (/space/mirror/Deploy/releases/20150324133527/node_modules/socket.io-redis-fixed-memleak/RedisAdapter.js:24:8)
```
